### PR TITLE
Show Tags in detail API view if no resources associated

### DIFF
--- a/orb/api/resources.py
+++ b/orb/api/resources.py
@@ -1,31 +1,28 @@
-
 import re
 
-from django.conf import settings
+from django.conf.urls import url
 from django.core.paginator import Paginator, InvalidPage
 from django.core.urlresolvers import reverse
-from django.conf.urls import url
 from django.http.response import Http404
 from django.utils.html import strip_tags
-
 from haystack.query import SearchQuerySet
-
-from orb.api.authorization import ORBResourceAuthorization, ORBAuthorization, ORBResourceTagAuthorization
-from orb.api.error_codes import *
-from orb.api.exceptions import ORBAPIBadRequest
-from orb.api.serializers import PrettyJSONSerializer, ResourceSerializer
-from orb.models import Resource, ResourceFile, ResourceURL, ResourceTag
-from orb.models import User, Tag, Category, ResourceTracker, SearchTracker
-from orb.signals import resource_viewed, search
-from orb.views import resource_can_edit
-
 from tastypie import fields
-from tastypie.constants import ALL
 from tastypie.authentication import ApiKeyAuthentication
+from tastypie.constants import ALL
 from tastypie.exceptions import Unauthorized
 from tastypie.resources import ModelResource
 from tastypie.throttle import CacheDBThrottle
 from tastypie.utils import trailing_slash
+
+from orb.api.authorization import (ORBResourceAuthorization, ORBAuthorization,
+                                   ORBResourceTagAuthorization)
+from orb.api.error_codes import *
+from orb.api.exceptions import ORBAPIBadRequest
+from orb.api.serializers import PrettyJSONSerializer, ResourceSerializer
+from orb.models import (Resource, ResourceFile, ResourceURL, ResourceTag, User,
+                        Tag, Category, ResourceTracker, SearchTracker)
+from orb.signals import resource_viewed, search
+from orb.views import resource_can_edit
 
 
 class TagBase(object):


### PR DESCRIPTION
The issue in #380 is that a Tastypie Resource has one queryset as it is intended to define a resource in general.

The solution itself ended up being quite simple, which is to remove the base queryset restriction - from active Tags to all Tags - and apply the exclusion only and explicitly to the `obj_get_list` method. Thus lists are filtered by tags which have at least one associated resource, while *key-based* access to a Tag detail is unrestricted based on resource association.