### PR TITLE
Use modals to show reviews to staff reviewer

### DIFF
--- a/orb/review/templatetags/review_tags.py
+++ b/orb/review/templatetags/review_tags.py
@@ -4,7 +4,7 @@ Template labels for content review
 
 from django import template
 
-from orb.models import ReviewerRole
+from orb.models import ReviewerRole, ResourceCriteria
 
 register = template.Library()
 
@@ -54,6 +54,16 @@ def status_labels(resource):
 
     return {
         'assignments': assignments,
+    }
+
+
+@register.inclusion_tag("orb/review/_selected_review_criteria.html")
+def selected_criteria(review):
+    selected = review.criteria.all()
+    unselected = ResourceCriteria.objects.for_role(review.role).exclude(pk__in=selected)
+    return {
+        'selected': selected,
+        'unselected': unselected,
     }
 
 

--- a/orb/templates/orb/review/_selected_review_criteria.html
+++ b/orb/templates/orb/review/_selected_review_criteria.html
@@ -1,10 +1,11 @@
-<strong>Selected Criteria</strong>
+{% load i18n %}
+<strong>{% trans 'Selected Criteria' %}</strong>
 <ul>
 {% for criterion in selected %}
     <li>{{ criterion }}</li>
 {% endfor %}
 </ul>
-<strong>Missing Criteria</strong>
+<strong>{% trans 'Missing Criteria' %}</strong>
 <ul>
 {% for criterion in unselected %}
     <li>{{ criterion }}</li>

--- a/orb/templates/orb/review/_selected_review_criteria.html
+++ b/orb/templates/orb/review/_selected_review_criteria.html
@@ -1,0 +1,12 @@
+<strong>Selected Criteria</strong>
+<ul>
+{% for criterion in selected %}
+    <li>{{ criterion }}</li>
+{% endfor %}
+</ul>
+<strong>Missing Criteria</strong>
+<ul>
+{% for criterion in unselected %}
+    <li>{{ criterion }}</li>
+{% endfor %}
+</ul>

--- a/orb/templates/orb/review/staff_review.html
+++ b/orb/templates/orb/review/staff_review.html
@@ -31,15 +31,14 @@
                     {% endif %}
 
                     {% if not review.is_pending %}
-                    <div class="modal fade" id="review-modal-{{ review.pk }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+                    <div class="modal fade" id="review-modal-{{ review.pk }}" tabindex="-1" role="dialog" aria-labelledby="modalLabel">
                       <div class="modal-dialog" role="document">
                         <div class="modal-content">
                           <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                            <h4 class="modal-title" id="myModalLabel">{{ review.get_status_display|title }}: {{ review.role }} by {{ review.reviewer }}</h4>
+                            <h4 class="modal-title" id="modalLabel">{{ review.get_status_display|title }}: {{ review.role }} by {{ review.reviewer }}</h4>
                           </div>
                           <div class="modal-body">
-                              <strong>Selected criteria</strong>:
                               {% selected_criteria review %}
                               <p>
                               <strong>{% trans 'Reviewer notes' %}</strong>: {{ review.notes }}

--- a/orb/templates/orb/review/staff_review.html
+++ b/orb/templates/orb/review/staff_review.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n crispy_forms_tags %}
+{% load i18n crispy_forms_tags review_tags %}
 {% block extra_head_title %}{% trans 'Content Review' %}{% endblock extra_head_title %}
 {% block content %}
 
@@ -22,8 +22,34 @@
                 {% endfor %}
                 {% for review in resource.content_reviews.all %}
                     <li>
-                        {{ review.role }}: {{ review.reviewer }}
-                        ({{ review.get_status_display|title }})
+                    {% if review.is_pending %}
+                        {{ review.role }}: {{ review.reviewer }} ({{ review.get_status_display|title }})
+                    {% else %}
+                    <a data-toggle="modal" data-target="#review-modal-{{ review.pk }}">
+                        {{ review.role }}: {{ review.reviewer }} ({{ review.get_status_display|title }})
+                    </a>
+                    {% endif %}
+
+                    {% if not review.is_pending %}
+                    <div class="modal fade" id="review-modal-{{ review.pk }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+                      <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title" id="myModalLabel">{{ review.get_status_display|title }}: {{ review.role }} by {{ review.reviewer }}</h4>
+                          </div>
+                          <div class="modal-body">
+                              <strong>Selected criteria</strong>:
+                              {% selected_criteria review %}
+                              <p>
+                              <strong>{% trans 'Reviewer notes' %}</strong>: {{ review.notes }}
+                              </p>
+                          </div>
+                        </div>
+                          </div>
+                    </div>
+                    {% endif %}
+
                     </li>
                 {% endfor %}
             </div>


### PR DESCRIPTION
The existing review summary (for a staff review) doesn't tell the final reviewer anything other than whether the review was approved or rejected.

This adds the review content in a modal, avoiding clutter in the page.

<img width="727" alt="screen shot 2016-10-18 at 13 32 05" src="https://cloud.githubusercontent.com/assets/102509/19489118/db07f02c-9537-11e6-945a-8b931cab2d35.png">
