### PR TITLE
Send email on final resource approval/rejection

### DIFF
--- a/orb/review/models.py
+++ b/orb/review/models.py
@@ -27,6 +27,7 @@ from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from django_fsm import FSMField, transition, TransitionNotAllowed
 
+import orb.signals
 from orb.models import TimestampBase, Resource, ReviewerRole
 from orb.review import signals, tasks
 
@@ -281,7 +282,7 @@ def review_approved(sender, review, **kwargs):
     process_resource_reviews(review.resource)
 
 
-@receiver(signals.resource_rejected)
+@receiver(orb.signals.resource_rejected)
 def resource_rejected(sender, resource, **kwargs):
     """
     Handles actions after a resource has been finally rejected
@@ -296,7 +297,7 @@ def resource_rejected(sender, resource, **kwargs):
     tasks.send_resource_rejected_email(resource)
 
 
-@receiver(signals.resource_approved)
+@receiver(orb.signals.resource_approved)
 def resource_approved(sender, resource, **kwargs):
     """
     Handles actions after a resource has been finally approved

--- a/orb/review/signals.py
+++ b/orb/review/signals.py
@@ -8,5 +8,3 @@ import django.dispatch
 review_assigned = django.dispatch.Signal(providing_args=["review", "assigned_by"])
 review_rejected = django.dispatch.Signal(providing_args=["review"])
 review_approved = django.dispatch.Signal(providing_args=["review"])
-resource_rejected = django.dispatch.Signal(providing_args=["resource"])
-resource_approved = django.dispatch.Signal(providing_args=["resource"])

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -99,6 +99,7 @@ def send_resource_rejected_email(resource):
         lastname=resource.create_user.last_name,
         info_email=settings.ORB_INFO_EMAIL,
         resource_link=current_site.domain + reverse('orb_resource', args=[resource.slug]),
+        notes=resource.workflow_trackers.rejected().notes(),
     )
 
 

--- a/orb/signals.py
+++ b/orb/signals.py
@@ -3,7 +3,7 @@ Signal definitions for ORB
 
 Should not contain any other handler or task functions
 """
-
+import django.dispatch
 from django.dispatch import Signal
 
 
@@ -17,3 +17,5 @@ search = Signal(
 tag_viewed = Signal(providing_args=["tag", "request", "type", "data"])
 user_registered = Signal(providing_args=["user", "request"])
 resource_submitted = Signal(providing_args=["resource", "request"])
+resource_rejected = django.dispatch.Signal(providing_args=["resource"])
+resource_approved = django.dispatch.Signal(providing_args=["resource"])

--- a/orb/templates/orb/email/resource_rejected.html
+++ b/orb/templates/orb/email/resource_rejected.html
@@ -1,19 +1,14 @@
-{% load i18n %} 
+{% load i18n %}
 {% blocktrans %}
 <p>Dear {{ firstname }} {{ lastname }},</p>
 
 <p>Thank you for submitting "{{ title }}" to the ORB platform.</p>
-
-<p>Unfortunately, your resource did not meet the following criteria to be included on ORB:</p>
+<p>Unfortunately, your resource did not meet the criteria to be included on ORB.</p>
 {% endblocktrans %}
-<ul>
-	{% for c in criteria %}
-		<li>{{ c.description }}</li>
-	{% endfor %} 
-</ul>
+
 {% blocktrans %}
-<p>The review team made the following comments:</p>	
-	
+<p>The review team made the following comments:</p>
+
 <p>"{{ notes }}"</p>
 {% endblocktrans %}
 

--- a/orb/templates/orb/email/resource_rejected.txt
+++ b/orb/templates/orb/email/resource_rejected.txt
@@ -1,19 +1,15 @@
-{% load i18n %} 
+{% load i18n %}
 {% blocktrans %}
 Dear {{ firstname }} {{ lastname }},
 
 Thank you for submitting "{{ title }}" to the ORB platform.
 
-Unfortunately, your resource did not meet the following criteria to be included on ORB:
+Unfortunately, your resource did not meet the criteria to be included on ORB.
 {% endblocktrans %}
 
-{% for c in criteria %}
-* {{ c.description }}
-{% endfor %} 
-
 {% blocktrans %}
-The review team made the following comments:	
-	
+The review team made the following comments:
+
 "{{ notes }}"
 {% endblocktrans %}
 {% include 'orb/email/footer.txt' %}


### PR DESCRIPTION
Involves removing criteria from final email as this is not collected
from the staff reviewer, only notes.

Notes are pulled from *possibly* multiple resource workflows. This
should really never be the case, but the queryset construction avoids
issues dealing with multiple relations inherent in the one-to-many
nature of the ForeignKey.

Closes gh-407