### PR TITLE
Update workflow email templates

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 1
 
    code
+   settings
    restapi
    language
    changelog

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,34 @@
+============
+ORB Settings
+============
+
+
+`ORB_INFO_EMAIL`
+    'orb@example.com'
+
+`ORB_GOOGLE_ANALYTICS_CODE`
+    Google Analytics tracking code
+
+`ORB_PAGINATOR_DEFAULT`
+    20
+
+`ORB_PARTNER_DATA_ENABLED`
+    False
+
+`ORB_RESOURCE_DESCRIPTION_MAX_WORDS`
+    150
+
+`ORB_RESOURCE_MIN_RATINGS`
+    3
+
+`SITE_HTTP_PROTOCOL`
+    boolean value which is used to toggle between `http` and `https` in full URLs
+
+`STAGING`
+    False  # used for version context processor
+
+`TASK_UPLOAD_FILE_MAX_SIZE`
+    maximum file upload size in bytes
+
+`TASK_UPLOAD_FILE_TYPE_BLACKLIST`
+    list of file types (MIME types) to exclude

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -22,7 +22,7 @@ ORB Settings
     3
 
 `SITE_HTTP_PROTOCOL`
-    boolean value which is used to toggle between `http` and `https` in full URLs
+    string value which should be either `'http'` or `'https'` (email tasks will default to `'http'` if this is not defined)
 
 `STAGING`
     False  # used for version context processor

--- a/orb/review/management/commands/test_task_emails.py
+++ b/orb/review/management/commands/test_task_emails.py
@@ -24,7 +24,8 @@ class Command(BaseCommand):
             'review_assignment': (tasks.send_review_assignment_email, ContentReview.reviews.all().first),
             'review_reminder': (tasks.send_review_reminder_email, ContentReview.reviews.all().first),
             'resource_approved': (tasks.send_resource_approved_email, resources_with_titles.first),
-            'resource_rejected': (tasks.send_resource_rejected_email, resources_with_titles.first),
+            'resource_rejected': (tasks.send_resource_rejected_email,
+                                  resources_with_titles.filter(status="rejected").first),
             'review_complete': (tasks.send_review_complete_email, resources_with_titles.first,
                                 [], {'verdict': Resource.APPROVED}),
         }

--- a/orb/review/management/commands/test_task_emails.py
+++ b/orb/review/management/commands/test_task_emails.py
@@ -1,0 +1,38 @@
+"""
+This is a debugging command designed to test emails on the system
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from orb.review import tasks
+from orb.review.models import ContentReview
+from orb.models import Resource
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    help = 'Checks for pending reviews and sends a reminder to the reviewer'
+
+    def handle(self, *args, **options):
+        if settings.EMAIL_BACKEND != 'django.core.mail.backends.console.EmailBackend':
+            # Guard against accidentally sending out emails
+            raise CommandError("You are using the '{}' email backend."
+                               "This command only runs using the console.EmailBackend.".format(settings.EMAIL_BACKEND))
+
+        task_names = {
+            'review_assignment': (tasks.send_review_assignment_email, ContentReview.reviews.all().first),
+            'review_reminder': (tasks.send_review_reminder_email, ContentReview.reviews.all().first),
+            'resource_approved': (tasks.send_resource_approved_email, Resource.objects.all().first)
+        }
+
+        for arg in args:
+            try:
+                function, callable = task_names[arg]
+            except ValueError as exc:
+                raise CommandError("Ooops: {}".format(exc))
+
+            self.stdout.write("Calling '{0}' using {1}".format(function, callable()))
+
+            function(callable())
+
+

--- a/orb/review/models.py
+++ b/orb/review/models.py
@@ -28,7 +28,7 @@ from django.utils.translation import ugettext_lazy as _
 from django_fsm import FSMField, transition, TransitionNotAllowed
 
 import orb.signals
-from orb.models import TimestampBase, Resource, ReviewerRole
+from orb.models import TimestampBase, Resource, ReviewerRole, ResourceCriteria
 from orb.review import signals, tasks
 
 
@@ -179,6 +179,16 @@ class ContentReview(TimestampBase):
             review_status=self.status,
             action="Reassigned from {0} to {1}".format(old_reviewer, new_user),
         )
+
+    def unmet_criteria(self):
+        """
+        Criteria applicable to this role that were unselected
+
+        Returns:
+            queryset of ResourceCriteria
+
+        """
+        return ResourceCriteria.criteria.for_role(self.role).exclude(id__in=self.criteria.all())
 
 
 def process_resource_reviews(resource):

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -62,7 +62,6 @@ def send_review_reminder_email(review):
         result of `send_mail` - 1 or 0
 
     """
-    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/review_reminder.html",
         template_text="orb/email/review_reminder.txt",
@@ -72,7 +71,7 @@ def send_review_reminder_email(review):
         resource_title=review.resource.title,
         review=review,
         review_age_days=7,
-        reviews_link=current_site.domain + reverse('orb_user_reviews'),
+        reviews_link=reverse_fqdn('orb_user_reviews'),
     )
 
 
@@ -118,7 +117,6 @@ def send_resource_approved_email(resource):
 
 
 def send_resource_rejected_email(resource):
-    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/resource_rejected.html",
         template_text="orb/email/resource_rejected.txt",
@@ -128,7 +126,7 @@ def send_resource_rejected_email(resource):
         firstname=resource.create_user.first_name,
         lastname=resource.create_user.last_name,
         info_email=settings.ORB_INFO_EMAIL,
-        resource_link=current_site.domain + reverse('orb_resource', args=[resource.slug]),
+        resource_link=reverse_fqdn('orb_resource', resource.slug),
         notes=resource.workflow_trackers.rejected().notes(),
     )
 
@@ -138,7 +136,6 @@ def send_review_complete_email(resource, **kwargs):
     Sends an email to staff recipients that all reviews for the given
     resource have been completed.
     """
-    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/review_complete.html",
         template_text="orb/email/review_complete.txt",
@@ -147,7 +144,7 @@ def send_review_complete_email(resource, **kwargs):
         title=resource.title,
         firstname=resource.create_user.first_name,
         lastname=resource.create_user.last_name,
-        resource_link=current_site.domain + reverse('orb_resource', args=[resource.slug]),
+        resource_link=reverse_fqdn('orb_resource', resource.slug),
         resource=resource,
         **kwargs
     )

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from orb.emailer import send_orb_email
+from orb.review.utils import unmet_criteria
 
 
 def reverse_fqdn(url_name, *args, **kwargs):
@@ -128,6 +129,7 @@ def send_resource_rejected_email(resource):
         info_email=settings.ORB_INFO_EMAIL,
         resource_link=reverse_fqdn('orb_resource', resource.slug),
         notes=resource.workflow_trackers.rejected().notes(),
+        rejected_criteria=unmet_criteria(resource),
     )
 
 

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -19,12 +19,14 @@ def send_review_assignment_email(review):
         result of `send_mail` - 1 or 0
 
     """
+    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/review_assignment.html",
         template_text="orb/email/review_assignment.txt",
-        subject=_(u"New content review assignment"),
+        subject=_(u"[ORB]: Content Review for: {}".format(review.resource)),
         recipients=[review.reviewer.email],
         review=review,
+        reviews_link=current_site.domain + reverse('orb_user_reviews'),
     )
 
 

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -8,6 +8,26 @@ from django.utils.translation import ugettext as _
 from orb.emailer import send_orb_email
 
 
+def reverse_fqdn(url_name, *args, **kwargs):
+    """
+    Returns a reversed URL including the fully qualified domain name and protocol
+
+    Args:
+        url_name: named URL
+        *args: positional arguments to pass to `reverse`
+        **kwargs: keyword arguments to pass to `reverse`
+
+    Returns:
+        the whole URL
+
+    """
+    return u"{protocol}://{domain}{path}".format(
+        protocol=getattr(settings, "SITE_HTTP_PROTOCOL", "http"),
+        domain=Site.objects.get_current().domain,
+        path=reverse(url_name, args=args, kwargs=kwargs),
+    )
+
+
 def send_review_assignment_email(review):
     """
     Sends an email to the assigned reviewer for the given review.
@@ -19,14 +39,16 @@ def send_review_assignment_email(review):
         result of `send_mail` - 1 or 0
 
     """
-    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/review_assignment.html",
         template_text="orb/email/review_assignment.txt",
         subject=_(u"Content Review for: ") + unicode(review.resource),
         recipients=[review.reviewer.email],
+        reviewer_name=review.reviewer.get_full_name(),
+        resource_title=review.resource.title,
+        reviewer_role=review.role.get_name_display(),
         review=review,
-        reviews_link=current_site.domain + reverse('orb_user_reviews'),
+        reviews_link=reverse_fqdn('orb_user_reviews'),
     )
 
 
@@ -46,6 +68,8 @@ def send_review_reminder_email(review):
         template_text="orb/email/review_reminder.txt",
         subject=_(u"Resource review reminder: ") + unicode(review.resource),
         recipients=[review.reviewer.email],
+        reviewer_name=review.reviewer.get_full_name(),
+        resource_title=review.resource.title,
         review=review,
         review_age_days=7,
         reviews_link=current_site.domain + reverse('orb_user_reviews'),
@@ -54,10 +78,13 @@ def send_review_reminder_email(review):
 
 def remind_reviewers(start_days=7, end_days=8):
     """
+    Sends reminders to reviewers for all late reviews created during a defined window
+
+    A window is defined by looking back
 
     Args:
-        start_days:
-        end_days:
+        start_days: the earlier number of days to go "back"
+        end_days: the final number of days to go "back"
 
     Returns:
         None
@@ -77,7 +104,6 @@ def remind_reviewers(start_days=7, end_days=8):
 
 
 def send_resource_approved_email(resource):
-    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/resource_approved.html",
         template_text="orb/email/resource_approved.txt",
@@ -87,7 +113,7 @@ def send_resource_approved_email(resource):
         firstname=resource.create_user.first_name,
         lastname=resource.create_user.last_name,
         info_email=settings.ORB_INFO_EMAIL,
-        resource_link=current_site.domain + reverse('orb_resource', args=[resource.slug]),
+        resource_link=reverse_fqdn('orb_resource', resource.slug),
     )
 
 

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -122,5 +122,6 @@ def send_review_complete_email(resource, **kwargs):
         firstname=resource.create_user.first_name,
         lastname=resource.create_user.last_name,
         resource_link=current_site.domain + reverse('orb_resource', args=[resource.slug]),
+        resource=resource,
         **kwargs
     )

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -23,7 +23,7 @@ def send_review_assignment_email(review):
     return send_orb_email(
         template_html="orb/email/review_assignment.html",
         template_text="orb/email/review_assignment.txt",
-        subject=_(u"[ORB]: Content Review for: {}".format(review.resource)),
+        subject=_(u"[ORB]: Content Review for: ") + unicode(review.resource),
         recipients=[review.reviewer.email],
         review=review,
         reviews_link=current_site.domain + reverse('orb_user_reviews'),
@@ -40,13 +40,15 @@ def send_review_reminder_email(review):
         result of `send_mail` - 1 or 0
 
     """
+    current_site = Site.objects.get_current()
     return send_orb_email(
         template_html="orb/email/review_reminder.html",
         template_text="orb/email/review_reminder.txt",
-        subject=_(u"Pending review reminder"),
+        subject=_(u"[ORB]: Resource review reminder: ") + unicode(review.resource),
         recipients=[review.reviewer.email],
         review=review,
         review_age_days=7,
+        reviews_link=current_site.domain + reverse('orb_user_reviews'),
     )
 
 

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -144,7 +144,7 @@ def send_review_complete_email(resource, **kwargs):
         title=resource.title,
         firstname=resource.create_user.first_name,
         lastname=resource.create_user.last_name,
-        resource_link=reverse_fqdn('orb_resource', resource.slug),
+        resource_link=reverse_fqdn('orb_staff_review', resource.pk),
         resource=resource,
         **kwargs
     )

--- a/orb/review/tasks.py
+++ b/orb/review/tasks.py
@@ -23,7 +23,7 @@ def send_review_assignment_email(review):
     return send_orb_email(
         template_html="orb/email/review_assignment.html",
         template_text="orb/email/review_assignment.txt",
-        subject=_(u"[ORB]: Content Review for: ") + unicode(review.resource),
+        subject=_(u"Content Review for: ") + unicode(review.resource),
         recipients=[review.reviewer.email],
         review=review,
         reviews_link=current_site.domain + reverse('orb_user_reviews'),
@@ -44,7 +44,7 @@ def send_review_reminder_email(review):
     return send_orb_email(
         template_html="orb/email/review_reminder.html",
         template_text="orb/email/review_reminder.txt",
-        subject=_(u"[ORB]: Resource review reminder: ") + unicode(review.resource),
+        subject=_(u"Resource review reminder: ") + unicode(review.resource),
         recipients=[review.reviewer.email],
         review=review,
         review_age_days=7,

--- a/orb/review/utils.py
+++ b/orb/review/utils.py
@@ -1,0 +1,26 @@
+"""
+Utility functions isolated to prevent circular dependencies
+"""
+
+
+def unmet_criteria(resource):
+    """
+    Returns criteria which were unselected for the resource.
+
+    Whether a criterion is unmet or not must take into account the context of
+    the reviewer's role, as a reviewer has only to select from general criteria
+    and the criteria specific to their role. Thus they may leave criteria
+    unchecked which does not indicate that the review failed baesd on these
+    criteria.
+
+    Args:
+        resource:
+
+    Returns:
+        an list of unique ResourceCriteria
+
+    """
+    unmet = []
+    for review in resource.content_reviews.all():
+        unmet += review.unmet_criteria()
+    return set(unmet)

--- a/orb/templates/orb/email/resource_rejected.html
+++ b/orb/templates/orb/email/resource_rejected.html
@@ -4,17 +4,14 @@
 
 <p>Thank you for submitting "{{ title }}" to the ORB platform.</p>
 <p>Unfortunately, your resource did not meet the following criteria to be included on ORB:</p>
-
-{{ bullet list of criteria not met (from all reviewers) }}
-
 {% endblocktrans %}
-
-
-
+    {% for criterion in rejected_criteria %}
+        <li>{{ criterion }}</li>
+    {% endfor %}
 {% blocktrans %}
 <p>The review team made the following comments:</p>
 
-<p>"{{ just the notes from mpowering final review (not all the reviewer comments) }}"</p>
+<p>"{{ notes }}"</p>
 
 {% endblocktrans %}
 

--- a/orb/templates/orb/email/resource_rejected.txt
+++ b/orb/templates/orb/email/resource_rejected.txt
@@ -4,12 +4,20 @@ Dear {{ firstname }} {{ lastname }},
 
 Thank you for submitting "{{ title }}" to the ORB platform.
 
-Unfortunately, your resource did not meet the criteria to be included on ORB.
+Unfortunately, your resource did not meet the following criteria to be included on ORB:
 {% endblocktrans %}
-
+    {% for criterion in rejected_criteria %}
+        <li>{{ criterion }}</li>
+    {% endfor %}
 {% blocktrans %}
 The review team made the following comments:
 
 "{{ notes }}"
+
 {% endblocktrans %}
+
+{% blocktrans %}
+We would be happy to discuss with you how the resource could be updated to meet our criteria.
+{% endblocktrans %}
+
 {% include 'orb/email/footer.txt' %}

--- a/orb/templates/orb/email/review_assignment.html
+++ b/orb/templates/orb/email/review_assignment.html
@@ -1,11 +1,10 @@
 {% load i18n %}
-{% url 'orb_resource_review' review.resource.pk review.pk as review_url %}
 {% blocktrans %}
 <p>Dear {{ review.reviewer.user.first_name }} {{ review.reviewer.lastname }},</p>
 
-<p>You have been assigned as the {{ role }} reviewer for the following resource on ORB: {{ review.resource.title }}</p>
+<p>You have been assigned as the {{ review.role }} reviewer for the following resource on ORB: {{ review.resource.title }}</p>
 
-<p>You can view all the resources pending your review <a href="{{ all_pending_full_url eg http://health-orb.org/}}">here on ORB</a> . 
+<p>You can view all the resources pending your review <a href="{{ reviews_link }}">here on ORB</a>.
 Please review this resource within the next 10 business days.</p>
 
 We appreciate your time and efforts in being part of the ORB content review team.

--- a/orb/templates/orb/email/review_assignment.html
+++ b/orb/templates/orb/email/review_assignment.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% blocktrans %}
-<p>Dear {{ review.reviewer.get_full_name }},</p>
+<p>Dear {{ reviewer_name }},</p>
 
-<p>You have been assigned as the {{ review.role }} reviewer for the following resource on ORB: {{ review.resource.title }}</p>
+<p>You have been assigned as the {{ reviewer_role }} reviewer for the following resource on ORB: {{ resource_title }}</p>
 
 <p>You can view all the resources pending your review <a href="{{ reviews_link }}">here on ORB</a>.
 Please review this resource within the next 10 business days.</p>

--- a/orb/templates/orb/email/review_assignment.html
+++ b/orb/templates/orb/email/review_assignment.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% blocktrans %}
-<p>Dear {{ review.reviewer.user.first_name }} {{ review.reviewer.lastname }},</p>
+<p>Dear {{ review.reviewer.get_full_name }},</p>
 
 <p>You have been assigned as the {{ review.role }} reviewer for the following resource on ORB: {{ review.resource.title }}</p>
 

--- a/orb/templates/orb/email/review_assignment.txt
+++ b/orb/templates/orb/email/review_assignment.txt
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% blocktrans %}
-Dear {{ review.reviewer.user.full_name }},
+Dear {{ review.reviewer.full_name }},
 
 You have been assigned as the {{ review.role }} reviewer for the following resource on ORB: {{ review.resource.title }}
 

--- a/orb/templates/orb/email/review_assignment.txt
+++ b/orb/templates/orb/email/review_assignment.txt
@@ -1,9 +1,13 @@
 {% load i18n %}
-{% url 'orb_resource_review' review.resource.pk review.pk as review_url %}
 {% blocktrans %}
-There is a new content resource for your review.
+Dear {{ review.reviewer.user.full_name }},
 
-You can access the content and make your review on the content dashboard: {{ review_url }}
+You have been assigned as the {{ review.role }} reviewer for the following resource on ORB: {{ review.resource.title }}
+
+You can view all the resources pending your review here on ORB: {{ reviews_link }}
+Please review this resource within the next 10 business days.
+
+We appreciate your time and efforts in being part of the ORB content review team.
 
 {% endblocktrans %}
-{% include 'orb/email/footer.txt' %}
+{% include 'orb/email/footer.html' %}

--- a/orb/templates/orb/email/review_assignment.txt
+++ b/orb/templates/orb/email/review_assignment.txt
@@ -1,10 +1,10 @@
 {% load i18n %}
 {% blocktrans %}
-Dear {{ review.reviewer.full_name }},
+Dear {{ reviewer_name }},
 
-You have been assigned as the {{ review.role }} reviewer for the following resource on ORB: {{ review.resource.title }}
+You have been assigned as the {{ reviewer_role }} reviewer for the following resource on ORB: {{ resource_title }}
 
-You can view all the resources pending your review here on ORB: {{ reviews_link }}
+You can view all the resources pending your review here on ORB: {{ reviews_link }}.
 Please review this resource within the next 10 business days.
 
 We appreciate your time and efforts in being part of the ORB content review team.

--- a/orb/templates/orb/email/review_assignment.txt
+++ b/orb/templates/orb/email/review_assignment.txt
@@ -10,4 +10,4 @@ Please review this resource within the next 10 business days.
 We appreciate your time and efforts in being part of the ORB content review team.
 
 {% endblocktrans %}
-{% include 'orb/email/footer.html' %}
+{% include 'orb/email/footer.txt' %}

--- a/orb/templates/orb/email/review_complete.html
+++ b/orb/templates/orb/email/review_complete.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% url 'orb_resource_review' review.resource.pk review.pk as review_url %}
 {% blocktrans %}
 <p>All content reviews for {{ resource }} are now complete. The overall recommendation is {{ verdict }}.</p>
 

--- a/orb/templates/orb/email/review_complete.txt
+++ b/orb/templates/orb/email/review_complete.txt
@@ -1,9 +1,8 @@
 {% load i18n %}
-{% url 'orb_resource_review' review.resource.pk review.pk as review_url %}
 {% blocktrans %}
 All content reviews for {{ resource }} are now complete. The overall recommendation is {{ verdict }}.
 
-You can make the final final review here: {{ resource_link }}
+You can make the final review here: {{ resource_link }}
 
 {% endblocktrans %}
 {% include 'orb/email/footer.txt' %}

--- a/orb/templates/orb/email/review_reminder.html
+++ b/orb/templates/orb/email/review_reminder.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% blocktrans %}
-<p>Dear {{ review.reviewer.get_full_name }},</p>
+<p>Dear {{ reviewer_name }},</p>
 
 <p>This is a reminder that you have an ORB content resource awaiting your review.</p>
 

--- a/orb/templates/orb/email/review_reminder.html
+++ b/orb/templates/orb/email/review_reminder.html
@@ -1,14 +1,10 @@
 {% load i18n %}
-{% url 'orb_resource_review' review.resource.pk review.pk as review_url %}
 {% blocktrans %}
-<p>Dear {{ reviewer name }},</p>
-
+<p>Dear {{ review.reviewer.get_full_name }},</p>
 
 <p>This is a reminder that you have an ORB content resource awaiting your review.</p>
 
-
-<p>You can access the content and make your review on the content dashboard:  {{ resource title & link}}</p>
-
+<p>You can access the content and make your review on <a href="{{ reviews_link }}">the content dashboard</a>.</p>
 
 {% endblocktrans %}
 {% include 'orb/email/footer.html' %}

--- a/orb/templates/orb/email/review_reminder.txt
+++ b/orb/templates/orb/email/review_reminder.txt
@@ -1,9 +1,9 @@
 {% load i18n %}
-{% url 'orb_resource_review' review.resource.pk review.pk as review_url %}
 {% blocktrans %}
-This is a reminder that you a content resource awaiting your review.
+Dear {{ review.reviewer.get_full_name }},
 
-You can access the content and make your review on the content dashboard: {{ review_url }}
+This is a reminder that you have an ORB content resource awaiting your review.
 
+You can access the content and make your review on the content dashboard: {{ reviews_link }}
 {% endblocktrans %}
-{% include 'orb/email/footer.txt' %}
+{% include 'orb/email/footer.html' %}

--- a/orb/templates/orb/email/review_reminder.txt
+++ b/orb/templates/orb/email/review_reminder.txt
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% blocktrans %}
-Dear {{ review.reviewer.get_full_name }},
+Dear {{ reviewer_name }},
 
 This is a reminder that you have an ORB content resource awaiting your review.
 

--- a/orb/templates/orb/email/review_reminder.txt
+++ b/orb/templates/orb/email/review_reminder.txt
@@ -6,4 +6,4 @@ This is a reminder that you have an ORB content resource awaiting your review.
 
 You can access the content and make your review on the content dashboard: {{ reviews_link }}
 {% endblocktrans %}
-{% include 'orb/email/footer.html' %}
+{% include 'orb/email/footer.txt' %}


### PR DESCRIPTION
Of note here is an added management command for testing, `test_task_emails`. It is set up to generate and send the named email, where the following emails can be generated by name:

- review_assignment
- review_reminder
- review_complete
- resource_approved
- resource_rejected

The command pulls largely arbitrary data as its purpose is to generate the email for review.

    ./manage.py test_task_emails resource_rejected

This command will bail out If your `EMAIL_BACKEND`  in settings is not set to `django.core.mail.backends.console.EmailBackend`. This both avoids accidental emails and also ensures that the email is printed to the console for review.