### PR TITLE
Fixes the bookmark view

### DIFF
--- a/orb/bookmark/views.py
+++ b/orb/bookmark/views.py
@@ -2,9 +2,8 @@
 
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.http import JsonResponse
-from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
@@ -31,7 +30,10 @@ def resource_bookmark_view(request):
     if resource_id is None:
         return HttpResponseBadRequest()
 
-    resource = get_object_or_404(Resource, pk=resource_id)
+    try:
+        resource = Resource.objects.get(pk=resource_id)
+    except Resource.DoesNotExist:
+        return HttpResponseBadRequest()
 
     try:
         collection = Collection.objects.get(visibility=Collection.PRIVATE, collectionuser__user=request.user)
@@ -44,13 +46,15 @@ def resource_bookmark_view(request):
     return JsonResponse({'success': True})
 
 
+@login_required
 def resource_bookmark_remove_view(request, resource_id):
-    if request.user.is_anonymous():
-        raise Http404()
     # check the current user is the owner of this bookmark
     try:
         bookmark = CollectionResource.objects.get(
-            resource__pk=resource_id, collection__visibility=Collection.PRIVATE, collection__collectionuser__user=request.user)
+            resource__pk=resource_id,
+            collection__visibility=Collection.PRIVATE,
+            collection__collectionuser__user=request.user,
+        )
     except CollectionResource.DoesNotExist:
         return HttpResponseBadRequest()
 

--- a/orb/bookmark/views.py
+++ b/orb/bookmark/views.py
@@ -1,53 +1,47 @@
 # orb/bookmark/views.py
-import json
 
+from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 
 from orb.models import Resource, Collection, CollectionUser, CollectionResource
 
 
+@login_required
+@csrf_exempt
+@require_POST
 def resource_bookmark_view(request):
-    if request.user.is_anonymous():
-        raise Http404()
-    if request.method == 'POST':
-        resource_id = request.POST.get('resource_id')
+    """
+    Creates a user bookmark for a resource
 
-        if resource_id is None:
-            return HttpResponseBadRequest()
+    Args:
+        request: HTTP request
 
-        resource = Resource.objects.get(pk=resource_id)
-        # check if user already has a bookmark collection object
-        try:
-            collection = Collection.objects.get(
-                visibility=Collection.PRIVATE, collectionuser__user=request.user)
-        # if not create it
-        except Collection.DoesNotExist:
-            collection = Collection()
-            collection.title = "My Bookmarks"
-            collection.user = request.user
-            collection.save()
+    Returns:
+        a JSON HTTP response
 
-            c_user = CollectionUser()
-            c_user.collection = collection
-            c_user.user = request.user
-            c_user.save()
+    """
 
-        # check if resource already bookmarked or not
-        bookmarked = CollectionResource.objects.filter(
-            resource=resource, collection=collection).count()
-        if bookmarked == 0:
-            cu = CollectionResource()
-            cu.collection = collection
-            cu.resource = resource
-            cu.save()
+    resource_id = request.POST.get('resource_id')
 
-        resp_obj = {}
-        resp_obj['success'] = True
-
-        return HttpResponse(json.dumps(resp_obj), content_type="application/json; charset=utf-8")
-    else:
+    if resource_id is None:
         return HttpResponseBadRequest()
+
+    resource = get_object_or_404(Resource, pk=resource_id)
+
+    try:
+        collection = Collection.objects.get(visibility=Collection.PRIVATE, collectionuser__user=request.user)
+    except Collection.DoesNotExist:
+        collection = Collection.objects.create(title="My Bookmarks")
+        CollectionUser.objects.create(collection=collection, user=request.user)
+
+    CollectionResource.objects.get_or_create(resource=resource, collection=collection)
+
+    return JsonResponse({'success': True})
 
 
 def resource_bookmark_remove_view(request, resource_id):

--- a/orb/views.py
+++ b/orb/views.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
 from django.core.urlresolvers import reverse
-from django.db import IntegrityError
 from django.db.models import Count, Max, Min, Q, Avg
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
@@ -14,8 +13,8 @@ from haystack.query import SearchQuerySet
 from orb.forms import (ResourceStep1Form, ResourceStep2Form, SearchForm,
                        ResourceRejectForm, AdvancedSearchForm)
 from orb.models import Collection
-from orb.models import ReviewerRole
 from orb.models import ResourceFile, ResourceTag, ResourceCriteria, ResourceRating
+from orb.models import ReviewerRole
 from orb.models import Tag, Resource, ResourceURL, Category, TagOwner, TagTracker, SearchTracker
 from orb.partners.OnemCHW.models import CountryData
 from orb.signals import (resource_viewed, resource_url_viewed, resource_file_viewed,


### PR DESCRIPTION
Remove CSRF req for bookmark view and fix some errors in the view, e.g. [this assignment](https://github.com/mPowering/django-orb/blob/39dd23427b51d9e752f13649bdf3df7bfa7f1d09/orb/bookmark/views.py#L28) to the user attribute on a Collection causes an error:

```python
except Collection.DoesNotExist:
    collection = Collection()
    collection.title = "My Bookmarks"
    collection.user = request.user
    collection.save()
```

Closes gh-429