### PR TITLE
Add translations to search 435

### DIFF
--- a/orb/templates/search/indexes/orb/resource_text.txt
+++ b/orb/templates/search/indexes/orb/resource_text.txt
@@ -1,10 +1,21 @@
-{{ object.title }}
-{{ object.description }}
+{% load translation_tags %}
+
+{% translated_fields object 'title' as title_values %}
+{% for title in title_values %}
+    {{ title }}
+{% endfor %}
+
+{% translated_fields object 'description' as description_values %}
+{% for description in description_values %}
+    {{ description }}
+{% endfor %}
 
 {% for tag in object.tags.all %}
-	{{ tag.name }}
+    {% translated_fields object 'name' as tag_name %}
+    {{ tag_name }}
 	{% if tag.parent_tag %}
-		{{ tag.parent_tag.name }}
+        {% translated_fields tag.parent_tag 'name' as parent_tag_name %}
+		{{ parent_tag_name }}
 	{% endif %}
 {% endfor %}
 

--- a/orb/templatetags/translation_tags.py
+++ b/orb/templatetags/translation_tags.py
@@ -1,0 +1,24 @@
+from django import template
+
+from django.conf import settings
+from modeltranslation.utils import build_localized_fieldname
+
+register = template.Library()
+
+
+@register.assignment_tag
+def translated_fields(obj, field_name):
+    """
+    Gets all of the translated values for a given field on an object
+
+    Args:
+        obj: a model instance
+        field_name: name of the translated model field
+
+    Returns:
+        a list of non-blank field values
+
+    """
+    field_names = [build_localized_fieldname(field_name, language[0]) for language in settings.LANGUAGES]
+    return [getattr(obj, trans_field) for trans_field in field_names if getattr(obj, trans_field, None)]
+

--- a/orb/tests/test_templatetags.py
+++ b/orb/tests/test_templatetags.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from orb.templatetags.translation_tags import translated_fields
+
+
+@pytest.mark.django_db
+def test_translated_fields_tag(test_resource, settings):
+    settings.LANGUAGES = [
+        ('en', u'English'),
+        ('es', u'Español'),
+        ('pt-br', u'Português'),
+    ]
+    test_resource.title_en = "Hey"
+    test_resource.title_pt_br = "Ei"
+    test_resource.description_en = "Hey"
+    test_resource.description_pt_br = "Ei"
+    test_resource.title_es = "hola"
+
+    assert set(translated_fields(test_resource, "title")) == {"Hey", "Ei", "hola"}
+    assert set(translated_fields(test_resource, "description")) == {"Hey", "Ei"}


### PR DESCRIPTION
Provisional update that adds translated values to the search `content` template.

It is, however, provisional, i.e. **_untested_**! ⚠️ ☠️ 

To fully update for translatable search we'd need to change the Solr analysis to use a keyword tokenizer.

gh-435