### PR TITLE
Hide health domains

### DIFF
--- a/orb/admin.py
+++ b/orb/admin.py
@@ -107,7 +107,7 @@ class SearchTrackerAdmin(admin.ModelAdmin):
 @admin.register(Tag)
 class TagAdmin(admin.ModelAdmin):
     list_display = ('name', 'category', 'external_url',
-                    'slug', 'parent_tag', 'order_by', 'image')
+                    'slug', 'published', 'parent_tag', 'order_by', 'image')
     search_fields = ['name', 'description']
     raw_id_fields = ('create_user', 'update_user', 'category', 'parent_tag')
 

--- a/orb/migrations/0043_tag_published.py
+++ b/orb/migrations/0043_tag_published.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orb', '0042_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='tag',
+            name='published',
+            field=models.BooleanField(default=True, help_text=b'Used to toggle status of health domains.'),
+        ),
+    ]

--- a/orb/models.py
+++ b/orb/models.py
@@ -17,7 +17,7 @@ from orb.analytics.models import UserLocationVisualization
 from orb.profiles.querysets import ProfilesQueryset
 from orb.resources.managers import ResourceURLManager, ResourceQueryset
 from orb.review.queryset import CriteriaQueryset
-from orb.tags.managers import ActiveTagManager, ResourceTagManager, TagQuerySet
+from orb.tags.managers import ResourceTagManager, TagQuerySet
 from .fields import AutoSlugField
 
 models.signals.post_save.connect(create_api_key, sender=User)
@@ -524,8 +524,7 @@ class Tag(TimestampBase):
     published = models.BooleanField(default=True, help_text="Used to toggle status of health domains.")
 
     tags = TagQuerySet.as_manager()
-    objects = tags  # backwards compatability
-    active = ActiveTagManager()
+    objects = tags  # backwards compatibility
 
     class Meta:
         verbose_name = _('Tag')

--- a/orb/models.py
+++ b/orb/models.py
@@ -17,7 +17,7 @@ from orb.analytics.models import UserLocationVisualization
 from orb.profiles.querysets import ProfilesQueryset
 from orb.resources.managers import ResourceURLManager, ResourceQueryset
 from orb.review.queryset import CriteriaQueryset
-from orb.tags.managers import ActiveTagManager, ResourceTagManager
+from orb.tags.managers import ActiveTagManager, ResourceTagManager, TagQuerySet
 from .fields import AutoSlugField
 
 models.signals.post_save.connect(create_api_key, sender=User)
@@ -509,7 +509,7 @@ class Category(models.Model):
 
 class Tag(TimestampBase):
     category = models.ForeignKey(Category)
-    parent_tag = models.ForeignKey('self', blank=True, null=True, default=None)
+    parent_tag = models.ForeignKey('self', blank=True, null=True, default=None, related_name="children")
     name = models.CharField(max_length=100)
     create_user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='tag_create_user')
     update_user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='tag_update_user')
@@ -521,8 +521,9 @@ class Tag(TimestampBase):
     description = models.TextField(blank=True, null=True, default=None)
     summary = models.CharField(blank=True, null=True, max_length=100)
     contact_email = models.CharField(blank=True, null=True, max_length=100)
+    published = models.BooleanField(default=True, help_text="Used to toggle status of health domains.")
 
-    tags = models.Manager()
+    tags = TagQuerySet.as_manager()
     objects = tags  # backwards compatability
     active = ActiveTagManager()
 

--- a/orb/tags/managers.py
+++ b/orb/tags/managers.py
@@ -24,36 +24,6 @@ class TagQuerySet(models.QuerySet):
         return approved_queryset(self.active(), user, relation="resourcetag__resource__")
 
 
-class ActiveTagManager(models.Manager):
-    """Manager for working only with tags with associated resources"""
-
-    def get_queryset(self):
-        return super(ActiveTagManager, self).get_queryset().filter(
-            resourcetag__isnull=False, published=True,
-        ).distinct()
-
-    def approved(self, user=None, qs=None):
-        """
-        Queryset that includes only tags with resources viewable by given user
-        based on approval state.
-
-        Args:
-            user (auth.User): the user to check 'permission' against
-
-        Returns:
-            QuerySet: A queryset filtered by status and/or user
-
-        """
-        qs = qs or super(ActiveTagManager, self).get_queryset()
-        if user is None:
-            user = AnonymousUser()
-        return approved_queryset(qs, user, relation="resourcetag__resource__")
-
-    def published(self):
-        qs = self.get_queryset().filter(published=True)
-        return self.approved(qs=qs)
-
-
 class ResourceTagManager(models.Manager):
     """Manager for the ResourceTag linking model"""
 

--- a/orb/tags/tests/test_managers.py
+++ b/orb/tags/tests/test_managers.py
@@ -20,9 +20,11 @@ class FixtureBase(TestCase):
         used_tag = tag_factory(user=cls.user)
         second_tag = tag_factory(user=cls.user)
         unused_tag = tag_factory(user=cls.user)  # noqa
+        non_public_tag = tag_factory(user=cls.user, published=False)
         ResourceTag.objects.create(create_user=cls.user, tag=used_tag, resource=resource)
         ResourceTag.objects.create(create_user=cls.user, tag=used_tag, resource=second_resource)
         ResourceTag.objects.create(create_user=cls.user, tag=second_tag, resource=second_resource)
+        ResourceTag.objects.create(create_user=cls.user, tag=non_public_tag, resource=second_resource)
 
     @classmethod
     def tearDownClass(cls):
@@ -39,14 +41,17 @@ class ActiveManagerTests(FixtureBase):
     The active manager only returns tags with associated resources
     """
     def test_default_manager(self):
-        self.assertEqual(Tag.objects.all().count(), 3)
+        self.assertEqual(Tag.objects.all().count(), 4)
+        self.assertEqual(Tag.tags.all().count(), 4)
 
     def test_active_manager(self):
         self.assertEqual(Tag.active.all().count(), 2)
+        self.assertEqual(Tag.tags.public().active().count(), 2)
 
     def test_approved_method(self):
         """Approved method only returns tags with approved resources"""
         self.assertEqual(Tag.active.approved().count(), 1)
+        self.assertEqual(Tag.tags.approved().count(), 1)
 
 
 class ResourceTagManagerTests(FixtureBase):
@@ -55,9 +60,9 @@ class ResourceTagManagerTests(FixtureBase):
     """
 
     def test_default_queryset(self):
-        self.assertEqual(ResourceTag.objects.all().count(), 3)
+        self.assertEqual(ResourceTag.objects.all().count(), 4)
 
     def test_approved_method(self):
         """Approved method only returns tags with approved resources"""
         self.assertEqual(ResourceTag.objects.approved().count(), 1)
-        self.assertEqual(ResourceTag.objects.approved(self.user).count(), 3)
+        self.assertEqual(ResourceTag.objects.approved(self.user).count(), 4)

--- a/orb/tags/tests/test_managers.py
+++ b/orb/tags/tests/test_managers.py
@@ -41,16 +41,13 @@ class ActiveManagerTests(FixtureBase):
     The active manager only returns tags with associated resources
     """
     def test_default_manager(self):
-        self.assertEqual(Tag.objects.all().count(), 4)
         self.assertEqual(Tag.tags.all().count(), 4)
 
     def test_active_manager(self):
-        self.assertEqual(Tag.active.all().count(), 2)
         self.assertEqual(Tag.tags.public().active().count(), 2)
 
     def test_approved_method(self):
         """Approved method only returns tags with approved resources"""
-        self.assertEqual(Tag.active.approved().count(), 1)
         self.assertEqual(Tag.tags.approved().count(), 1)
 
 

--- a/orb/views.py
+++ b/orb/views.py
@@ -22,28 +22,16 @@ from orb.signals import (resource_viewed, resource_url_viewed, resource_file_vie
 
 def home_view(request):
     topics = []
-    tags = Tag.objects.filter(category__top_level=True,
-                              parent_tag=None).order_by('order_by')
-    for t in tags:
-        # get child tags
-        child_tags = Tag.objects.filter(parent_tag=t).values_list('id')
+    for tag in Tag.tags.public().top_level():
 
+        child_tags = tag.children.values_list('id')
         resource_count = Resource.objects.filter(status=Resource.APPROVED).filter(
-            Q(resourcetag__tag__pk__in=child_tags) | Q(resourcetag__tag=t)).distinct().count()
-        data = {}
-        data['resource_count'] = resource_count
-        data['tag'] = t
-        topics.append(data)
+            Q(resourcetag__tag__pk__in=child_tags) | Q(resourcetag__tag=tag)).distinct().count()
 
-    '''
-    data = {}
-    data['resource_count'] = 3
-    data['custom'] = True
-    data['url'] = reverse('orb_toolkits_home')
-    data['title'] = _(u'Toolkits')
-    data['image'] = 'toolkit.png'
-    topics.append(data)
-    '''
+        topics.append({
+            'resource_count': resource_count,
+            'tag': tag,
+        })
 
     return render(request, 'orb/home.html', {
         'topics': topics,


### PR DESCRIPTION
Tags (health domains) can all be published or unpublished. They are published by default.

Includes some replacement of traditional manager classes with more composable queryset methods. 

**NOTE** this should, although does not *need* to, follow the [pull request for language selection](https://github.com/mPowering/django-orb/pull/451), because that includes 4d1774a5b23538ba1341a68b22772e42fb1a6fc1 which fixes a test error. That commit can be added otherwise later, so it is not _critical_ that #451 precede this pull request, but it'll help with running tests.