### PR TITLE
Preserve tag ordering from resources

### DIFF
--- a/orb/models.py
+++ b/orb/models.py
@@ -236,7 +236,7 @@ class Resource(TimestampBase):
         categories = Category.objects.filter(tag__resourcetag__resource=self).exclude(
             slug='license').distinct().order_by('order_by')
         for c in categories:
-            c.tags = Tag.objects.filter(resourcetag__resource=self, category=c)
+            c.tags = Tag.tags.filter(category=c).by_resource(self)
         return categories
 
     def get_category(self, category_slug):
@@ -261,29 +261,19 @@ class Resource(TimestampBase):
         return anon + identified
 
     def get_geographies(self):
-        tags = Tag.objects.filter(
-            resourcetag__resource=self, category__slug='geography')
-        return tags
+        return Tag.tags.by_category('geography').by_resource(self)
 
     def get_devices(self):
-        tags = Tag.objects.filter(
-            resourcetag__resource=self, category__slug='device')
-        return tags
+        return Tag.tags.by_category('device').by_resource(self)
 
     def get_languages(self):
-        tags = Tag.objects.filter(
-            resourcetag__resource=self, category__slug='language')
-        return tags
+        return Tag.tags.by_category('language').by_resource(self)
 
     def get_license(self):
-        tags = Tag.objects.filter(
-            resourcetag__resource=self, category__slug='license')
-        return tags
+        return Tag.tags.by_category('license').by_resource(self)
 
     def get_health_domains(self):
-        tags = Tag.objects.filter(
-            resourcetag__resource=self, category__slug='health-domain')
-        return tags
+        return Tag.tags.by_category('health-domain').by_resource(self)
 
     def get_rating(self):
         rating = ResourceRating.objects.filter(resource=self).aggregate(
@@ -590,6 +580,7 @@ class ResourceTag(models.Model):
 
     class Meta:
         unique_together = ("resource", "tag")
+        ordering = ('id',)
 
     @classmethod
     def create_from_api_data(cls, resource, api_data, user=None):

--- a/orb/tags/managers.py
+++ b/orb/tags/managers.py
@@ -23,6 +23,19 @@ class TagQuerySet(models.QuerySet):
             user = AnonymousUser()
         return approved_queryset(self.active(), user, relation="resourcetag__resource__")
 
+    def by_resource(self, resource):
+        """
+        Returns a queryset related to the specific resource
+
+        Ordering is preserved against the order in which the association between
+        each tag and the resource was added.
+        """
+        return self.filter(resourcetag__resource=resource).order_by('resourcetag__id')
+
+    def by_category(self, category_slug):
+        """"""
+        return self.filter(category__slug=category_slug)
+
 
 class ResourceTagManager(models.Manager):
     """Manager for the ResourceTag linking model"""

--- a/orb/tests/test_site.py
+++ b/orb/tests/test_site.py
@@ -23,7 +23,7 @@ class SiteTest(TestCase):
 
     def test_pages(self):
         url_names = [
-            'orb_home', 'orb_about', 'orb_developers', 'orb_how_to', 'orb_partners',
+            'orb_home', 'orb_about', 'orb_how_to', 'orb_partners',
             'orb_taxonomy', 'orb_terms', 'orb_tag_cloud', 'orb_resource_create',
             'orb_guidelines', 'orb_search', 'orb_search_advanced', 'orb_opensearch',
         ]


### PR DESCRIPTION
No need to track an ordering value! The ID is added sequentially, the only requirement is to return `Tags` ordered against the intermediary `ResourceTag.id`.