### PR TITLE
Evaluate lazy translation strings for API

### DIFF
--- a/orb/api/exceptions.py
+++ b/orb/api/exceptions.py
@@ -3,14 +3,16 @@ import json
 
 from orb.api.error_codes import *
 from tastypie.exceptions import BadRequest
+from django.utils.encoding import force_text
 
 
 class ORBAPIBadRequest(BadRequest):
 
     def __init__(self, error_code, pk=None):
-
-        # Call the base class constructor with the parameters it needs
-        error = {"code": error_code, "message": ERROR_CODES[error_code]}
+        error = {
+            "code": error_code,
+            "message": force_text(ERROR_CODES[error_code]),
+        }
 
         if pk:
             error['pk'] = pk


### PR DESCRIPTION
Because these strings are dumped into a JSON object they need to be evaluated before being serialized, otherwise this results in TypeErrors.

```
TypeError: <django.utils.functional.__proxy__ object at 0x10d127150> is not JSON serializable
```