### PR TITLE
Ensure tag names are checked against local lang and default field

### DIFF
--- a/orb/fixtures/__init__.py
+++ b/orb/fixtures/__init__.py
@@ -14,8 +14,8 @@ from orb.resources.tests.factory import resource_factory
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture(scope="session")
-def test_user():
+@pytest.fixture
+def testing_user():
     user, _ = User.objects.get_or_create(username="tester")
     yield user
 
@@ -26,27 +26,26 @@ def import_user():
     yield user
 
 
-
-@pytest.fixture(scope="session")
-def test_category():
+@pytest.fixture
+def sample_category():
     category, _ = Category.objects.get_or_create(name="test category")
     yield category
 
 
-@pytest.fixture(scope="session")
-def test_tag(test_category, test_user):
+@pytest.fixture
+def sample_tag(sample_category, testing_user):
     tag, _ = Tag.objects.get_or_create(name="test tag", defaults={
-        "category": test_category,
-        "create_user": test_user,
-        "update_user": test_user,
+        "category": sample_category,
+        "create_user": testing_user,
+        "update_user": testing_user,
     })
     yield tag
 
 
-@pytest.fixture(scope="session")
-def test_resource(test_user):
+@pytest.fixture
+def test_resource(testing_user):
     yield resource_factory(
-        user=test_user,
+        user=testing_user,
         title=u"Básica salud del recién nacido",
         description=u"Básica salud del recién nacido",
     )

--- a/orb/resources/tests/test_models.py
+++ b/orb/resources/tests/test_models.py
@@ -116,10 +116,11 @@ class TestResourceLocality(object):
         test_resource.source_peer = test_peer
         assert not test_resource.is_local()
 
-    def test_sourced_resource(self, test_resource):
+    def test_sourced_resource(self, test_resource, test_peer):
         """Both a source name and host should mark a resource as not local"""
         test_resource.source_name = "Another ORB"
         test_resource.source_host = "http://www.yahoo.com"
+        test_resource.source_peer = test_peer
         assert not test_resource.is_local()
 
 

--- a/orb/resources/tests/test_views.py
+++ b/orb/resources/tests/test_views.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for ORB resource views
+"""
+from __future__ import unicode_literals
+
+import pytest
+from django.utils import translation
+
+from orb.models import Tag
+from orb.views import resource_add_free_text_tags
+
+
+@pytest.mark.django_db
+def test_default_language_duplicate_tags(sample_category, testing_user, test_resource):
+    """
+    Duplicate tags should not be added based on duplicate name across current language to default
+
+    This should result in no errors
+
+    """
+    t = Tag.tags.create(
+        name="My Fun Test",
+        category=sample_category,
+        create_user=testing_user,
+        update_user=testing_user,
+    )
+
+    tag_text = "My Fun Test"
+
+    resource_add_free_text_tags(test_resource, tag_text, testing_user, t.category.slug)
+    assert Tag.tags.all().count() == 1
+
+    translation.activate("es")
+
+    resource_add_free_text_tags(test_resource, tag_text, testing_user, t.category.slug)
+    assert Tag.tags.all().count() == 1
+
+    Tag.tags.all().delete()
+    translation.deactivate()
+
+
+@pytest.mark.django_db
+def test_other_language_duplicate_tags(sample_category, testing_user, test_resource):
+    t = Tag.tags.create(
+        name="Child",
+        name_es="Niño",
+        category=sample_category,
+        create_user=testing_user,
+        update_user=testing_user,
+    )
+
+    assert Tag.tags.all().count() == 1
+
+    translation.activate("es")
+
+    tag_text = "Child"
+    resource_add_free_text_tags(test_resource, tag_text, testing_user, t.category.slug)
+    assert Tag.tags.all().count() == 1
+
+    tag_text = "Niño"
+    resource_add_free_text_tags(test_resource, tag_text, testing_user, t.category.slug)
+    assert Tag.tags.all().count() == 1
+
+    Tag.tags.all().delete()
+
+    translation.deactivate()

--- a/orb/views.py
+++ b/orb/views.py
@@ -888,16 +888,35 @@ def resource_add_free_text_tags(resource, tag_text, user, category_slug):
     category = Category.objects.get(slug=category_slug)
 
     for tag_name in free_text_tags:
-        tag, created = Tag.tags.get_or_create(name=tag_name, defaults={
-            'category': category,
-            'create_user': user,
-            'update_user': user,
-        })
+        try:
+            tag = Tag.tags.rewrite(False).get(name=tag_name)
+        except Tag.DoesNotExist:
+            try:
+                tag = Tag.tags.get(name=tag_name)
+            except Tag.DoesNotExist:
+                tag = Tag.tags.create(
+                    name=tag_name,
+                    category=category,
+                    create_user=user,
+                    update_user=user,
+                )
         ResourceTag.objects.get_or_create(
             tag=tag, resource=resource, defaults={'create_user': user})
 
 
 def resource_add_tags(request, form, resource):
+    """
+    Adds structured tags to the resource
+
+    Args:
+        request: the HttpRequest
+        form: Resource add/edit form that has the tag data
+        resource: the resource to add the tags
+
+    Returns:
+        None
+
+    """
     tag_categories = ["health_topic", "resource_type", "audience", "device"]
     for tc in tag_categories:
         tag_category = form.cleaned_data.get(tc)


### PR DESCRIPTION
This prevents the scenario where the lookup for an existing tag returns nothing
beacuse the tag name, present in the default name field, is not returned for the
current language translation. E.g. a tag was added in English as "Medicine"
which adds "Medicine" to both the `name` and `name_en` database fields.

If then someone is using the site in Spanish, the modeltranslation query will
automatically query *only* the `name_es` field. Finding nothing, an attempt is
made to create a tag named "Medicine", which puts "Medicine" into both the
`name_es` and `name` fields. Since both fields have unique constraints, this
fails on the `name` field.

The update here checks both the default field and current translated field.

Fixes gh-458

-----

Note that this update is limited to the 'other' tags section.