### PR TITLE
Add defusedxml 0.5.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,5 +30,6 @@ django-fsm==2.4.0
 
 
 django-extensions==1.7.5
+defusedxml==0.5.0
 
 git+https://github.com/mPowering/orb-api-python.git@v0.1.1#orb_api


### PR DESCRIPTION
Safe XML handling - this resolves a trivial but unnecessary exception when `format=json` is not specified