### PR TITLE
Clean survey data to include only pertinent data

### DIFF
--- a/orb/resources/forms.py
+++ b/orb/resources/forms.py
@@ -69,7 +69,19 @@ class ResourceAccessForm(forms.Form):
 
     def clean(self):
         data = self.cleaned_data
+
         intended_use = data.get('survey_intended_use')
+        exclude = {
+            'browsing': ['survey_intended_use_other', 'survey_health_worker_count', 'survey_health_worker_cadre'],
+            'learning': ['survey_intended_use_other', 'survey_health_worker_count', 'survey_health_worker_cadre'],
+            'training': ['survey_intended_use_other'],
+            'other': ['survey_health_worker_count', 'survey_health_worker_cadre'],
+        }
+
+        for field in exclude.get(intended_use, []):
+            if field in data:
+                del data[field]
+
         use_other = data.get('survey_intended_use_other')
         worker_count = data.get('survey_health_worker_count', 0)
         worker_cadre = data.get('survey_health_worker_cadre')

--- a/orb/resources/tests/test_forms.py
+++ b/orb/resources/tests/test_forms.py
@@ -97,9 +97,6 @@ def test_resource_access_form(role_tag, intended_use, use_intended_use, intended
     }
 
     form = forms.ResourceAccessForm(data=data)
-
-    uses = dict(forms.ResourceAccessForm.INTENDED_USE)
-
     form_validity = True
 
     if any([
@@ -121,3 +118,9 @@ def test_resource_access_form(role_tag, intended_use, use_intended_use, intended
 
     assert form_validity == form.is_valid()
 
+    if form_validity:
+        if survey_intended_use in ['browsing', 'learning', 'other']:
+            assert not form.cleaned_data.get('survey_health_worker_count')
+            assert not form.cleaned_data.get('survey_health_worker_cadre')
+        if survey_intended_use in ['browsing', 'learning', 'training']:
+            assert not form.cleaned_data.get('survey_intended_use_other')


### PR DESCRIPTION
This means that if someone has entered, say, a number of health workers
and a cadre, and then chooses a use other than 'learning', this data
will not be saved to the database.