### PR TITLE
Add view to download resource URL/file stats

### DIFF
--- a/orb/analytics/urls.py
+++ b/orb/analytics/urls.py
@@ -1,13 +1,15 @@
-from django.conf.urls import patterns
 from django.conf.urls import url
 
+from orb.analytics import views
+
 urlpatterns = [
-    url(r'^$', 'orb.analytics.views.home_view', name="orb_analytics_home"),
-    url(r'^mailinglist/$', 'orb.analytics.views.mailing_list_view', name="orb_analytics_mailing_list"),
-    url(r'^visitor/$', 'orb.analytics.views.visitor_view', name="orb_analytics_visitor"),
-    url(r'^visitor/(?P<year>\d+)/(?P<month>\d+)/$', 'orb.analytics.views.visitor_view', name="orb_analytics_visitor_month_view"),
-    url(r'^map/$', 'orb.analytics.views.map_view', name="orb_analytics_map"),
-    url(r'^tag/(?P<id>\d+)/$', 'orb.analytics.views.tag_view', name="orb_analytics_tag"),
-    url(r'^tag/(?P<id>\d+)/download/(?P<year>\d+)/(?P<month>\d+)/$', 'orb.analytics.views.tag_download', name="orb_analytics_download"),
-    url(r'^resource/(?P<id>\d+)/$', 'orb.analytics.views.resource_view', name="orb_analytics_resource"),
+    url(r'^$', view=views.home_view, name="orb_analytics_home"),
+    url(r'^mailinglist/$', view=views.mailing_list_view, name="orb_analytics_mailing_list"),
+    url(r'^visitor/$', view=views.visitor_view, name="orb_analytics_visitor"),
+    url(r'^visitor/(?P<year>\d+)/(?P<month>\d+)/$', view=views.visitor_view, name="orb_analytics_visitor_month_view"),
+    url(r'^map/$', view=views.map_view, name="orb_analytics_map"),
+    url(r'^tag/(?P<id>\d+)/$', view=views.tag_view, name="orb_analytics_tag"),
+    url(r'^tag/(?P<id>\d+)/download/(?P<year>\d+)/(?P<month>\d+)/$', view=views.tag_download, name="orb_analytics_download"),
+    url(r'^resource/(?P<id>\d+)/$', view=views.resource_view, name="orb_analytics_resource"),
+    url(r'^assets/$', view=views.resource_tracker_stats, name="orb_resource_asset_stats"),
 ]

--- a/orb/models.py
+++ b/orb/models.py
@@ -16,7 +16,7 @@ from tastypie.models import create_api_key
 from orb import signals
 from orb.analytics.models import UserLocationVisualization
 from orb.profiles.querysets import ProfilesQueryset
-from orb.resources.managers import ResourceQueryset, ResourceURLManager
+from orb.resources.managers import ResourceQueryset, ResourceURLManager, TrackerQueryset
 from orb.review.queryset import CriteriaQueryset
 from orb.tags.managers import ResourceTagManager, TagQuerySet
 from .fields import AutoSlugField
@@ -755,6 +755,8 @@ class ResourceTracker(models.Model):
     survey_intended_use_other = models.TextField(blank=True, null=True, default="")
     survey_health_worker_count = models.IntegerField(blank=True, null=True)
     survey_health_worker_cadre = models.CharField(max_length=50, blank=True, null=True)
+
+    objects = TrackerQueryset.as_manager()
 
     def get_location(self):
         return UserLocationVisualization.objects.filter(ip=self.ip).first()


### PR DESCRIPTION
The view returns only data related to resource URLs or resource files by filtering on the [`resource_assets` queryset method](https://github.com/mPowering/django-orb/compare/master...wellfire:download-orb-stats?expand=1#diff-6beef291dda1edc7f232d20068050467R141), and the [`export_data` method](https://github.com/mPowering/django-orb/compare/master...wellfire:download-orb-stats?expand=1#diff-6beef291dda1edc7f232d20068050467R145) is responsible for returning an iterator of tuples of the ordered export data.

The CSV format is used here due to a [possibly minor] error in an Excel export related to datetimes (more specifically an issue related to naive datetimes). Since the CSV format suffices we're sticking with it (for now).

Note: a URL is configured but not otherwise linked from anywhere.