### PR TITLE
Upgrade to Django 1.11

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -19,7 +19,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = '*****************************'
 
 DEBUG = True
-TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'testserver']
 
@@ -74,18 +73,29 @@ MIDDLEWARE_CLASSES = [
 
 #####################################################################
 # Templates
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static",
-    "django.core.context_processors.request",
-    "django.contrib.messages.context_processors.messages",
-    'orb.context_processors.get_menu',
-    'orb.context_processors.get_version',
-    'orb.context_processors.base_context_processor',
-)
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+                'orb.context_processors.get_menu',
+                'orb.context_processors.get_version',
+                'orb.context_processors.base_context_processor',
+            ],
+            'debug': DEBUG,
+        },
+    },
+]
+
 #####################################################################
 
 
@@ -216,7 +226,6 @@ LOGGING = {
 ORB_RESOURCE_DESCRIPTION_MAX_WORDS = 150
 ORB_GOOGLE_ANALYTICS_CODE = ''
 ORB_INFO_EMAIL = 'orb@example.com'
-ORB_RESOURCE_DESCRIPTION_MAX_WORDS = 150
 ORB_PAGINATOR_DEFAULT = 20
 ORB_RESOURCE_MIN_RATINGS = 3
 TASK_UPLOAD_FILE_TYPE_BLACKLIST = [u'application/vnd.android']

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.views import static
 
 admin.autodiscover()
 
@@ -11,5 +12,4 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += [
-        url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-            {'document_root': settings.MEDIA_ROOT})]
+        url(r'^media/(?P<path>.*)$', static.serve, {'document_root': settings.MEDIA_ROOT})]

--- a/orb/api/urls.py
+++ b/orb/api/urls.py
@@ -4,6 +4,7 @@ from tastypie.api import Api
 from orb.api.resources import (ResourceResource, CategoryResource, TagResource,
                                ResourceTagResource, ResourceFileResource,
                                ResourceURLResource, TagsResource)
+from orb.api import upload
 
 v1_api = Api(api_name='v1')
 v1_api.register(ResourceResource())
@@ -16,6 +17,6 @@ v1_api.register(CategoryResource())
 
 urlpatterns = [
     url(r'^', include(v1_api.urls)),
-    url(r'^upload/image/$', 'orb.api.upload.image_view', name="orb_image_upload"),
-    url(r'^upload/file/$', 'orb.api.upload.file_view', name="orb_file_upload"),
+    url(r'^upload/image/$', upload.image_view, name="orb_image_upload"),
+    url(r'^upload/file/$', upload.file_view, name="orb_file_upload"),
 ]

--- a/orb/bookmark/urls.py
+++ b/orb/bookmark/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url
 
+from orb.bookmark import views
+
 
 urlpatterns = [
-    url(r'^$', 'orb.bookmark.views.resource_bookmark_view', name="orb_bookmark"),
-    url(r'^remove/(?P<resource_id>\d+)/$',
-        'orb.bookmark.views.resource_bookmark_remove_view', name="orb_bookmark_remove"),
+    url(r'^$', views.resource_bookmark_view, name="orb_bookmark"),
+    url(r'^remove/(?P<resource_id>\d+)/$', views.resource_bookmark_remove_view, name="orb_bookmark_remove"),
 ]

--- a/orb/forms.py
+++ b/orb/forms.py
@@ -110,6 +110,7 @@ class ResourceStep1Form(forms.Form):
 
         super(ResourceStep1Form, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
+        self.helper.attrs = {'novalidate': True}
         self.helper.form_class = 'form-horizontal'
         self.helper.label_class = 'col-lg-2'
         self.helper.field_class = 'col-lg-8'
@@ -434,7 +435,7 @@ class AdvancedSearchForm(forms.Form):
     def search(self):
         """
         Implements the filtered search
-        
+
         Returns:
             a tuple of a queryset and list of Tags
 

--- a/orb/models.py
+++ b/orb/models.py
@@ -102,7 +102,8 @@ class Resource(TimestampBase):
     tags = models.ManyToManyField('Tag', through='ResourceTag', blank=True)
 
     resources = ResourceQueryset.as_manager()
-    objects = resources  # alias
+    objects = ResourceQueryset.as_manager()
+    # objects = resources  # alias
 
     # Fields to strip from API data
     API_EXCLUDED_FIELDS = ['id', 'guid']
@@ -320,7 +321,8 @@ class ResourceWorkflowTracker(models.Model):
     owner_email_sent = models.BooleanField(default=False, blank=False)
 
     workflows = WorkflowQueryset.as_manager()
-    objects = workflows  # Backwards compatible alias
+    objects = WorkflowQueryset.as_manager()
+    # objects = workflows  # Backwards compatible alias
 
 
 class ResourceURL(TimestampBase):
@@ -486,7 +488,8 @@ class ResourceCriteria(models.Model):
     )
 
     criteria = CriteriaQueryset.as_manager()
-    objects = criteria
+    objects = CriteriaQueryset.as_manager()
+    # objects = criteria
 
     def get_role_display(self):
         """Returns an appropriate label for the admin"""
@@ -538,7 +541,8 @@ class Tag(TimestampBase):
     published = models.BooleanField(default=True, help_text=_(u"Used to toggle status of health domains."))
 
     tags = TagQuerySet.as_manager()
-    objects = tags  # backwards compatibility
+    objects = TagQuerySet.as_manager()
+    # objects = tags  # backwards compatibility
 
     class Meta:
         verbose_name = _('Tag')
@@ -708,7 +712,8 @@ class UserProfile(TimestampBase):
     reviewer_roles = models.ManyToManyField('ReviewerRole', blank=True, related_name="profiles")
 
     profiles = ProfilesQueryset.as_manager()
-    objects = profiles
+    objects = ProfilesQueryset.as_manager()
+    # objects = profiles
 
     class Meta:
         db_table = "orb_userprofile"
@@ -884,7 +889,8 @@ class ReviewerRole(models.Model):
     name = models.CharField(max_length=100, choices=ROLE_CHOICES, unique=True, default='medical')
 
     roles = models.Manager()
-    objects = roles
+    objects = models.Manager()
+    # objects = roles
 
     def __unicode__(self):
         return self.get_name_display()

--- a/orb/profiles/urls.py
+++ b/orb/profiles/urls.py
@@ -2,18 +2,20 @@ from django.conf.urls import url
 from django.views.generic import TemplateView
 
 from orb.profiles import views
+from django.contrib.auth.views import logout
+from django.views.i18n import set_language
 
 urlpatterns = [
     url(r'^register/$', view=views.RegistrationView.as_view(), name="profile_register"),
     url(r'^register/thanks/$', TemplateView.as_view(template_name="orb/thanks.html"), name="profile_register_thanks"),
-    url(r'^login/$', 'orb.profiles.views.login_view', name="profile_login"),
-    url(r'^logout/$', 'django.contrib.auth.views.logout', {'template_name': 'orb/logout.html'}, name="profile_logout"),
-    url(r'^setlang/$', 'django.views.i18n.set_language', name="profile_set_language"),
-    url(r'^reset/$', 'orb.profiles.views.reset', name="profile_reset"),
+    url(r'^login/$', views.login_view, name="profile_login"),
+    url(r'^logout/$', logout, {'template_name': 'orb/logout.html'}, name="profile_logout"),
+    url(r'^setlang/$', set_language, name="profile_set_language"),
+    url(r'^reset/$', views.reset, name="profile_reset"),
     url(r'^reset/sent/$', TemplateView.as_view(template_name="orb/profile/reset-sent.html"), name="profile_reset_sent"),
-    url(r'^view/(?P<id>\d+)/$', 'orb.profiles.views.view_profile', name="profile_view"),
-    url(r'^edit/$', 'orb.profiles.views.edit', name="my_profile_edit"),
-    url(r'^view/$', 'orb.profiles.views.view_my_profile', name="my_profile_view"),
-    url(r'^view/bookmarks/$', 'orb.profiles.views.view_my_bookmarks', name="my_bookmarks_view"),
-    url(r'^view/ratings/$', 'orb.profiles.views.view_my_ratings', name="my_ratings_view"),
+    url(r'^view/(?P<id>\d+)/$', views.view_profile, name="profile_view"),
+    url(r'^edit/$', views.edit, name="my_profile_edit"),
+    url(r'^view/$', views.view_my_profile, name="my_profile_view"),
+    url(r'^view/bookmarks/$', views.view_my_bookmarks, name="my_bookmarks_view"),
+    url(r'^view/ratings/$', views.view_my_ratings, name="my_ratings_view"),
 ]

--- a/orb/profiles/views.py
+++ b/orb/profiles/views.py
@@ -36,10 +36,7 @@ def login_view(request):
         user = authenticate(username=username, password=password)
         if user is not None and user.is_active:
             login(request, user)
-            if next is not None:
-                return HttpResponseRedirect(next)
-            else:
-                return HttpResponseRedirect(reverse('orb_home'))
+            return redirect(next) if next else redirect(reverse('orb_home'))
     else:
         form = LoginForm(initial={'next': request.GET.get('next'), })
 

--- a/orb/rating/urls.py
+++ b/orb/rating/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
+from orb.rating import views
 
 urlpatterns = [
-    url(r'^$', 'orb.rating.views.resource_rate_view', name="orb_rate"),
+    url(r'^$', views.resource_rate_view, name="orb_rate"),
 ]

--- a/orb/resources/urls.py
+++ b/orb/resources/urls.py
@@ -2,27 +2,28 @@ from django.conf.urls import url
 
 from orb.resources.views import ResourceFileView
 from orb.resources.views import ResourceURLView
+from orb import views
 
 urlpatterns = [
-    url(r'^create/1/$', 'orb.views.resource_create_step1_view', name="orb_resource_create"),
-    url(r'^create/2/(?P<id>\d+)/$', 'orb.views.resource_create_step2_view', name="orb_resource_create2"),
-    url(r'^create/(?P<id>\d+)/thanks/$', 'orb.views.resource_create_thanks_view', name="orb_resource_create_thanks"),
-    url(r'^view/(?P<resource_slug>\w[\w/-]*)$', 'orb.views.resource_view', name="orb_resource"),
-    url(r'^(?P<id>\d+)$', 'orb.views.resource_permalink_view', name="orb_resource_permalink"),
-    url(r'^create/(?P<id>\d+)/link/(?P<url_id>\d+)/delete/$', 'orb.views.resource_create_url_delete_view', name="orb_resource_create_delete_url"),
-    url(r'^create/(?P<id>\d+)/file/(?P<file_id>\d+)/delete/$', 'orb.views.resource_create_file_delete_view', name="orb_resource_create_delete_file"),
+    url(r'^create/1/$', views.resource_create_step1_view, name="orb_resource_create"),
+    url(r'^create/2/(?P<id>\d+)/$', views.resource_create_step2_view, name="orb_resource_create2"),
+    url(r'^create/(?P<id>\d+)/thanks/$', views.resource_create_thanks_view, name="orb_resource_create_thanks"),
+    url(r'^view/(?P<resource_slug>\w[\w/-]*)$', views.resource_view, name="orb_resource"),
+    url(r'^(?P<id>\d+)$', views.resource_permalink_view, name="orb_resource_permalink"),
+    url(r'^create/(?P<id>\d+)/link/(?P<url_id>\d+)/delete/$', views.resource_create_url_delete_view, name="orb_resource_create_delete_url"),
+    url(r'^create/(?P<id>\d+)/file/(?P<file_id>\d+)/delete/$', views.resource_create_file_delete_view, name="orb_resource_create_delete_file"),
     url(r'^link/(?P<id>\d+)/$', ResourceURLView.as_view(), name="orb_resource_view_link"),
     url(r'^file/(?P<id>\d+)/$', ResourceFileView.as_view(), name="orb_resource_view_file"),
-    url(r'^edit/1/(?P<resource_id>\d+)/$', 'orb.views.resource_edit_view', name="orb_resource_edit"),
-    url(r'^edit/2/(?P<resource_id>\d+)/$', 'orb.views.resource_edit_step2_view', name="orb_resource_edit2"),
-    url(r'^edit/(?P<id>\d+)/link/(?P<url_id>\d+)/delete/$', 'orb.views.resource_edit_url_delete_view', name="orb_resource_edit_delete_url"),
-    url(r'^edit/(?P<id>\d+)/file/(?P<file_id>\d+)/delete/$', 'orb.views.resource_edit_file_delete_view', name="orb_resource_edit_delete_file"),
-    url(r'^edit/(?P<id>\d+)/thanks/$', 'orb.views.resource_edit_thanks_view', name="orb_resource_edit_thanks"),
+    url(r'^edit/1/(?P<resource_id>\d+)/$', views.resource_edit_view, name="orb_resource_edit"),
+    url(r'^edit/2/(?P<resource_id>\d+)/$', views.resource_edit_step2_view, name="orb_resource_edit2"),
+    url(r'^edit/(?P<id>\d+)/link/(?P<url_id>\d+)/delete/$', views.resource_edit_url_delete_view, name="orb_resource_edit_delete_url"),
+    url(r'^edit/(?P<id>\d+)/file/(?P<file_id>\d+)/delete/$', views.resource_edit_file_delete_view, name="orb_resource_edit_delete_file"),
+    url(r'^edit/(?P<id>\d+)/thanks/$', views.resource_edit_thanks_view, name="orb_resource_edit_thanks"),
 
-    url(r'^approve/(?P<id>\d+)/$', 'orb.views.resource_approve_view', name="orb_resource_approve"),
-    url(r'^pending_mep/(?P<id>\d+)/$', 'orb.views.resource_pending_mep_view', name="orb_resource_pending_mep"),
-    url(r'^reject/(?P<id>\d+)/$', 'orb.views.resource_reject_view', name="orb_resource_reject"),
-    url(r'^reject/(?P<id>\d+)/sent/$', 'orb.views.resource_reject_sent_view', name="orb_resource_reject_sent"),
+    url(r'^approve/(?P<id>\d+)/$', views.resource_approve_view, name="orb_resource_approve"),
+    url(r'^pending_mep/(?P<id>\d+)/$', views.resource_pending_mep_view, name="orb_resource_pending_mep"),
+    url(r'^reject/(?P<id>\d+)/$', views.resource_reject_view, name="orb_resource_reject"),
+    url(r'^reject/(?P<id>\d+)/sent/$', views.resource_reject_sent_view, name="orb_resource_reject_sent"),
 
-    url(r'^guidelines/$', 'orb.views.resource_guidelines_view', name="orb_guidelines"),
+    url(r'^guidelines/$', views.resource_guidelines_view, name="orb_guidelines"),
 ]

--- a/orb/review/templatetags/review_tags.py
+++ b/orb/review/templatetags/review_tags.py
@@ -86,4 +86,4 @@ def can_start_review(context, resource):
     if not profile.is_reviewer:
         return False
     # TODO this is wrong
-    return not resource.content_reviews.filter(role__in=profile.reviewer_roles.all).exists()
+    return not resource.content_reviews.filter(role__in=profile.reviewer_roles.all()).exists()

--- a/orb/templates/includes/header.html
+++ b/orb/templates/includes/header.html
@@ -77,7 +77,7 @@
                             <li><a href="{% url 'my_bookmarks_view' %}">{% trans 'Bookmarks' %}</a>
                             </li>
                             <li>
-                                <a href="{% url 'django.contrib.auth.views.logout' %}">{% trans 'Logout' %}</a>
+                                <a href="{% url 'profile_logout' %}">{% trans 'Logout' %}</a>
                             </li>
                         </ul>
                     </li>

--- a/orb/templates/orb/partners.html
+++ b/orb/templates/orb/partners.html
@@ -1,9 +1,9 @@
-{% extends "base.html" %} 
-{% load i18n %} 
+{% extends "base.html" %}
+{% load i18n %}
 {% load thumbnail %}
 {% block extra_head_title %}
 	{% trans 'Content Partners' %}
-{% endblock extra_head_title %} 
+{% endblock extra_head_title %}
 
 {% block content %}
 
@@ -33,7 +33,7 @@
 	Content Partners should have an internal quality assurance and review
 	process in place, as this will help us fast-track your ORB resources
 	through our content review process.</p>
-	
+
 <p>The criteria for becoming a content partner are:</p>
 
 <ul>
@@ -62,9 +62,9 @@
 
 
 {% for p in partners %}
-<div class="row" style="padding-bottom:20px"> 
+<div class="row" style="padding-bottom:20px">
 	<div class="col-md-1">
-		<a href="{% url 'orb.views.tag_view' p.slug %}" title="{% blocktrans with p.name as org %}View all {{ org }} resources on ORB{% endblocktrans %}">
+		<a href="{% url 'orb_tags' p.slug %}" title="{% blocktrans with p.name as org %}View all {{ org }} resources on ORB{% endblocktrans %}">
 		{% thumbnail p.image "70x70" format="PNG" padding=True as im %}
 				<img src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}"
 					alt="{% blocktrans with p.name as org %}View all {{ org }} resources on ORB{% endblocktrans %}">
@@ -74,14 +74,14 @@
 	<div class="col-md-8">
 		<h4>{{ p.name }}</h4>
 		<p>{{ p.description|safe }}<br/>
-		{% if p.slug = 'jhu-ccp' %}
-			<a href="{% url 'orb.views.tag_view' 'nurhi' %}">{% blocktrans %}View all NURHI project resources on ORB{% endblocktrans %}</a><br/>
-			<a href="{% url 'orb.views.tag_view' 'ghana-behavior-change-support' %}">{% blocktrans %}View all Ghana BCS project resources on ORB{% endblocktrans %}</a></p>
+		{% if p.slug == 'jhu-ccp' %}
+			<a href="{% url 'orb_tags' 'nurhi' %}">{% blocktrans %}View all NURHI project resources on ORB{% endblocktrans %}</a><br/>
+			<a href="{% url 'orb_tags' 'ghana-behavior-change-support' %}">{% blocktrans %}View all Ghana BCS project resources on ORB{% endblocktrans %}</a></p>
 		{% else %}
-			<a href="{% url 'orb.views.tag_view' p.slug %}">{% blocktrans with p.name as org %}View all {{ org }} resources on ORB{% endblocktrans %}</a></p>
+			<a href="{% url 'orb_tags' p.slug %}">{% blocktrans with p.name as org %}View all {{ org }} resources on ORB{% endblocktrans %}</a></p>
 		{%endif %}
 	</div>
-	
+
 </div>
 {% endfor %}
 {% endblock content %}

--- a/orb/templatetags/add_get_parameter.py
+++ b/orb/templatetags/add_get_parameter.py
@@ -1,4 +1,4 @@
-from django.template import Library, Node, resolve_variable
+from django.template import Library, Node, Variable
 
 register = Library()
 
@@ -34,7 +34,7 @@ class AddGetParameter(Node):
         self.values = values
 
     def render(self, context):
-        req = resolve_variable('request', context)
+        req = Variable('request').resolve(context)
         params = req.GET.copy()
         for key, value in self.values.items():
             params[key] = value.resolve(context)

--- a/orb/templatetags/display_functions.py
+++ b/orb/templatetags/display_functions.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from django import template
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from django.utils.safestring import mark_safe
 
 from orb import conf
 
@@ -45,7 +46,7 @@ def resourcefile_link(context, resourcefile, alternate_link):
         url = alternate_link
         title = _("Please login on register to download these files or access these links")
         css_class = 'disabled-link'
-    return file_link.format(url=url, title=title, css_class=css_class)
+    return mark_safe(file_link.format(url=url, title=title, css_class=css_class))
 
 
 @register.simple_tag(takes_context=True)
@@ -64,4 +65,4 @@ def resourceurl_link(context, resourceurl, alternate_link):
         url = alternate_link
         title = _("Please login on register to download these files or access these links")
         css_class = 'disabled-link'
-    return link_link.format(url=url, title=title, css_class=css_class)
+    return mark_safe(link_link.format(url=url, title=title, css_class=css_class))

--- a/orb/tests/test_site.py
+++ b/orb/tests/test_site.py
@@ -189,8 +189,7 @@ class SiteTest(TestCase):
                 self.assertEqual(tracker_count_start + 1, tracker_count_end)
 
     def test_resources_pending(self):
-        pending_resources = Resource.objects.filter(
-            status=Resource.PENDING)
+        pending_resources = Resource.objects.filter(status=Resource.PENDING)
 
         if FAST_TESTS:
             pending_resources = pending_resources[:1]

--- a/orb/tests/utils.py
+++ b/orb/tests/utils.py
@@ -5,11 +5,11 @@ Utility functions for enhancing the reusability and readability of test code
 from functools import wraps
 
 import mock
+from importlib import import_module
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
-from django.utils.importlib import import_module
 
 
 def request_factory(factory=None, user=None, userprofile=None, method='GET', **kwargs):

--- a/orb/urls.py
+++ b/orb/urls.py
@@ -1,35 +1,36 @@
 from django.conf.urls import include, url
 from django.views.generic import TemplateView
 
+from orb import views
 from orb.feeds import LatestEntries, LatestTagEntries
 
 urlpatterns = [
-    url(r'^$', 'orb.views.home_view', name="orb_home"),
+    url(r'^$', views.home_view, name="orb_home"),
     url(r'^robots.txt$', TemplateView.as_view(template_name="orb/robots.txt")),
     url(r'^about/$', TemplateView.as_view(template_name="orb/about.html"), name="orb_about"),
     url(r'^feed/$', LatestEntries(), name="orb_feed"),
     url(r'^how-to/$', TemplateView.as_view(template_name="orb/how_to.html"), name="orb_how_to"),
     url(r'^cc-faq/$', TemplateView.as_view(template_name="orb/cc-faq.html"), name="orb_cc_faq"),
-    url(r'^partners/$', 'orb.views.partner_view', name="orb_partners"),
-    url(r'^taxonomy/$', 'orb.views.taxonomy_view', name="orb_taxonomy"),
+    url(r'^partners/$', views.partner_view, name="orb_partners"),
+    url(r'^taxonomy/$', views.taxonomy_view, name="orb_taxonomy"),
     url(r'^terms/$', TemplateView.as_view(template_name="orb/terms.html"), name="orb_terms"),
 
     url(r'^profile/', include('orb.profiles.urls')),
 
-    url(r'^tag/view/(?P<tag_slug>\w[\w/-]*)$', 'orb.views.tag_view', name="orb_tags"),
+    url(r'^tag/view/(?P<tag_slug>\w[\w/-]*)$', views.tag_view, name="orb_tags"),
     url(r'^tag/feed/(?P<tag_slug>\w[\w/-]*)$', LatestTagEntries(), name="orb_tag_feed"),
 
     url(r'^tag/', include('orb.tags.urls')),
 
-    url(r'^collection/view/(?P<collection_slug>\w[\w/-]*)$', 'orb.views.collection_view', name="orb_collection"),
+    url(r'^collection/view/(?P<collection_slug>\w[\w/-]*)$', views.collection_view, name="orb_collection"),
 
     url(r'^analytics/', include('orb.analytics.urls')),
 
     url(r'^tinymce/', include('tinymce.urls')),
-    url(r'^search/$', 'orb.views.search_view', name="orb_search"),
-    url(r'^search/advanced/$', 'orb.views.search_advanced_view', name="orb_search_advanced"),
-    url(r'^search/advanced/(?P<tag_id>\d+)/$', 'orb.views.search_advanced_view', name="orb_search_advanced_prefill"),
-    url(r'^search/advanced/results/$', 'orb.views.search_advanced_results_view', name="orb_search_advanced_results"),
+    url(r'^search/$', views.search_view, name="orb_search"),
+    url(r'^search/advanced/$', views.search_advanced_view, name="orb_search_advanced"),
+    url(r'^search/advanced/(?P<tag_id>\d+)/$', views.search_advanced_view, name="orb_search_advanced_prefill"),
+    url(r'^search/advanced/results/$', views.search_advanced_results_view, name="orb_search_advanced_results"),
     url(r'^opensearch/$', TemplateView.as_view(template_name="search/opensearch.html"), name="orb_opensearch"),
 
     url(r'^api/', include('orb.api.urls')),

--- a/orb/viz/urls.py
+++ b/orb/viz/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns
 from django.conf.urls import url
 
+from orb.viz import views
 
 urlpatterns = [
-    url(r'^country/$', 'orb.viz.views.country_map_view', name="orb_country_map"),
+    url(r'^country/$', views.country_map_view, name="orb_country_map"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 # Isolating Django from the other requirements allows better cross-version
 # (Django) testing.
 
-Django==1.8.17
+Django==1.11.11
 -r requirements/base.txt
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ six==1.9.0
 polib==1.0.8                            # Translation file loading
 
 Pillow>=2.7.0,<3.0.0
-sorl-thumbnail>=12.0,<13.0
+sorl-thumbnail>=12.4,<13.0
 textract>=1.2.0,<1.3.0
 Unidecode==0.04.19
 parsedatetime==2.2
@@ -21,11 +21,11 @@ parsedatetime==2.2
 django-tastypie==0.13.3
 django-tablib>=0.9.11,<4.0
 django-crispy-forms>=1.4.0,<2.0
-django-tinymce>=1.5.0,<2.0
+django-tinymce>=2.6.0,<2.7.0
 django-wysiwyg>=0.7.0,<1.0
-django-haystack>=2.3.0,<2.4.0
+django-haystack>=2.5.0,<2.6.0
 django-autoslug==1.9.3
-django-modeltranslation==0.9
+django-modeltranslation>=0.12,<0.13
 django-fsm==2.4.0
 
 


### PR DESCRIPTION
This solves the issue of email length.

Testing wise I've verified that the test suite is passing (with the exception of the search API test which fails on my own machine due to lack of local Solr setup), and run through a few of the steps manually, including registration, submitting a resource, assigning a resource for review, and approving a resource. There may be edge cases or processes that haven't been subject to test which pose problems.

The core changes that will have to be separately updated include the settings and the requirements, as both required some updates (see below).

The changes to the project dependencies is pretty straightforward, upgrading the Django version and several dependencies which were incompatible in their previous versions with Django 1.11.

The settings may be a *bit* trickier as the settings for templates, specifically, have changed and I've configured the settings below for a situation in which the only templates used are from the `orb` app here. This may need to be amended if there are any templates in use in the 'wrapper' or parent project used for hosting this, but I don't think that's the case.